### PR TITLE
Better margins on mobile home page

### DIFF
--- a/sass/custom/_styles.scss
+++ b/sass/custom/_styles.scss
@@ -74,6 +74,7 @@ article img {
   -moz-box-shadow: 3px 3px 8px #555; /* Firefox */
   -webkit-box-shadow: 3px 3px 8px #555; /* Safari, Chrome */
   box-shadow: 3px 3px 8px #555; /* CSS3 */
+  width: 100%;
 }
 article h2 {
   background: transparent;
@@ -237,7 +238,6 @@ body#index h1 {
 }
 #index .photo {
   float: left;
-  max-width: 480px;
   margin-right: 20px;
 }
 #summary {
@@ -288,7 +288,7 @@ body#index h1 {
 }
 #mini-speaker-photos {
   padding-top: 0px;
-  margin: 0 0 150px;
+  margin: 0 0 15px;
   float: left;
   max-width: 660px;
 }
@@ -303,6 +303,7 @@ body#index h1 {
   max-width: 240px;
   font-size: 80%;
   line-height: 1.4;
+  height: 380px;
 }
 #mini-bio h4 {
   font-size: 120%;


### PR DESCRIPTION
The new mobile enhancements look great! A huge improvement!

This commit tightens up the home page a little.
- scale the Pittsburgh skyline photo
- remove vertical gap between speaker photos and bios
